### PR TITLE
FIX Skip broken chunks

### DIFF
--- a/oct_converter/dicom/e2e_meta.py
+++ b/oct_converter/dicom/e2e_meta.py
@@ -24,15 +24,17 @@ def e2e_patient_meta(meta: dict) -> PatientMeta:
     """
     patient = PatientMeta()
 
-    patient_data = meta.get("patient_data", [{}])
-
-    patient.first_name = patient_data[0].get("first_name")
-    patient.last_name = patient_data[0].get("surname")
-    patient.patient_id = patient_data[0].get("patient_id")
-    patient.patient_sex = patient_data[0].get("sex")
-    # TODO patient.patient_dob
-    # Currently, E2E's patient_dob is incorrect, see
-    # the E2E reader for more context.
+    patient_data = meta.get("patient_data")
+    if patient_data:
+        # Heidelberg's updated anonymization process wipes
+        # this section of metadata
+        patient.first_name = patient_data[0].get("first_name")
+        patient.last_name = patient_data[0].get("surname")
+        patient.patient_id = patient_data[0].get("patient_id")
+        patient.patient_sex = patient_data[0].get("sex")
+        # TODO patient.patient_dob
+        # Currently, E2E's patient_dob is incorrect, see
+        # the E2E reader for more context.
 
     return patient
 

--- a/oct_converter/readers/e2e.py
+++ b/oct_converter/readers/e2e.py
@@ -37,6 +37,7 @@ class E2E(object):
         self.acquisition_date = None
         self.birthdate = None
         self.pixel_spacing = None
+        self.patient_id = None
 
         # get initial directory structure
         with open(self.filepath, "rb") as f:
@@ -129,7 +130,13 @@ class E2E(object):
             for start, pos in chunk_stack:
                 f.seek(start + self.byte_skip)
                 raw = f.read(60)
-                chunk = e2e_binary.chunk_structure.parse(raw)
+                try:
+                    # Heidelberg's updated anonymization seems to cause problems with
+                    # some chunks. Observed problems include an empty raw and problems
+                    # with undecodable bytes. For now, these chunks are skipped...
+                    chunk = e2e_binary.chunk_structure.parse(raw)
+                except Exception:
+                    continue
 
                 if chunk.type == 9:  # patient data
                     raw = f.read(127)
@@ -358,7 +365,13 @@ class E2E(object):
             for start, pos in chunk_stack:
                 f.seek(start + self.byte_skip)
                 raw = f.read(60)
-                chunk = e2e_binary.chunk_structure.parse(raw)
+                try:
+                    # Heidelberg's updated anonymization seems to cause problems with
+                    # some chunks. Observed problems include an empty raw and problems
+                    # with undecodable bytes. For now, these chunks are skipped...
+                    chunk = e2e_binary.chunk_structure.parse(raw)
+                except Exception:
+                    continue
 
                 if chunk.type == 9:  # patient data
                     raw = f.read(127)
@@ -489,7 +502,13 @@ class E2E(object):
             for start, pos in chunk_stack:
                 f.seek(start + self.byte_skip)
                 raw = f.read(60)
-                chunk = e2e_binary.chunk_structure.parse(raw)
+                try:
+                    # Heidelberg's updated anonymization seems to cause problems with
+                    # some chunks. Observed problems include an empty raw and problems
+                    # with undecodable bytes. For now, these chunks are skipped...
+                    chunk = e2e_binary.chunk_structure.parse(raw)
+                except Exception:
+                    continue
 
                 image_string = "{}_{}_{}".format(
                     chunk.patient_db_id, chunk.study_id, chunk.series_id


### PR DESCRIPTION
Encountered a few new E2E files that were raising the following errors,

```
'ascii' codec can't decode byte 0xc7 in position 0: ordinal not in range(128), b'\xc7\xd7\xbe\x00\x00\x00\x003\xc4\x00\x00\x00\x00\xbf\xbd\xad\xc1\x00\x00}\xc4\x00\x00\x00\x00\x00\x00\x9f\xc5\x8d\xc6\xac\xc1\x00\x00%\xc4\xba\xc0\r\xc3\x00\x00\x00\x00\x00\x00\xd7\xc4\x83\xc1\x00\x00\x06\xb1?\xc3)\xc4\x00'
```
and
```
Error in path (parsing) -> magic3
stream read less than specified amount, expected 12, found 0, b''
```

This is a quick skip for those spots. Also fixes DICOM metadata creator spot that depended on some of the now-erased chunks.