### PR TITLE
Add AcquisitionDateTime to output DICOMs

### DIFF
--- a/oct_converter/dicom/e2e_meta.py
+++ b/oct_converter/dicom/e2e_meta.py
@@ -159,7 +159,7 @@ def e2e_dicom_metadata(
         meta.series_info = e2e_series_meta(
             image.image_id,
             image.laterality,
-            None,
+            image.acquisition_date,
             image.metadata,
         )
         meta.image_geometry = e2e_image_geom(image.pixel_spacing)

--- a/oct_converter/image_types/fundus.py
+++ b/oct_converter/image_types/fundus.py
@@ -23,6 +23,7 @@ class FundusImageWithMetaData(object):
         patient_id: patient ID.
         image_id: image ID.
         DOB: patient date of birth.
+        acquisition_date: date and time of image acquisition.
         metadata: all metadata parsed from the original file.
         pixel_spacing: [x, y] pixel spacing in mm
     """
@@ -34,6 +35,7 @@ class FundusImageWithMetaData(object):
         patient_id: str | None = None,
         image_id: str | None = None,
         patient_dob: str | None = None,
+        acquisition_date: str | None = None,
         metadata: dict | None = None,
         pixel_spacing: list[float] | None = None,
     ) -> None:
@@ -42,6 +44,7 @@ class FundusImageWithMetaData(object):
         self.patient_id = patient_id
         self.image_id = image_id
         self.DOB = patient_dob
+        self.acquisition_date = acquisition_date
         self.metadata = metadata
         self.pixel_spacing = pixel_spacing
 

--- a/oct_converter/readers/e2e.py
+++ b/oct_converter/readers/e2e.py
@@ -440,6 +440,7 @@ class E2E(object):
                         laterality=laterality_dict[key]
                         if key in laterality_dict.keys()
                         else None,
+                        acquisition_date=self.acquisition_date,
                         metadata=metadata,
                         pixel_spacing=[scalex, scalex],
                     )


### PR DESCRIPTION
This PR saves the `AcquisitionDateTime` into the output DICOMs.

It has been tested successfully on e2e files for which the acquisition date was known.